### PR TITLE
🔨 refactor: enforcing line length in go code

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -5,3 +5,6 @@
 
 # ruff check --fix
 af7086c3713c284227ce4d94baa7c5a7fb007aae
+
+# golines
+42060236d8247486d3287ac0dcb4725c985adb81

--- a/src/client/cmd/session.go
+++ b/src/client/cmd/session.go
@@ -30,14 +30,23 @@ This is based on the vocab list and the session config file provided.`,
 		}
 
 		if serverPort < 1 || serverPort > 65535 {
-			return fmt.Errorf("server-port must be a valid port number between 1 and 65535")
+			return fmt.Errorf(
+				"server-port must be a valid port number between 1 and 65535",
+			)
 		}
 
 		return nil
 	},
 
 	RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive
-		p := tea.NewProgram(sessiontui.InitialModel(sessionConfigPath, vocabListPath, numberOfQuestions, serverPort))
+		p := tea.NewProgram(
+			sessiontui.InitialModel(
+				sessionConfigPath,
+				vocabListPath,
+				numberOfQuestions,
+				serverPort,
+			),
+		)
 		if _, err := p.Run(); err != nil {
 			return err
 		}
@@ -49,10 +58,14 @@ This is based on the vocab list and the session config file provided.`,
 func init() {
 	rootCmd.AddCommand(sessionCmd)
 
-	sessionCmd.Flags().StringVarP(&sessionConfigPath, "session-config", "c", "", "Path to the session config .json file")
-	sessionCmd.Flags().StringVarP(&vocabListPath, "vocab-list", "l", "", "Path to the vocab list .txt file")
-	sessionCmd.Flags().IntVarP(&numberOfQuestions, "number", "n", 0, "Number of questions for the session")
-	sessionCmd.Flags().IntVarP(&serverPort, "server-port", "p", 5000, "Localhost port for the server (default is 5000)")
+	sessionCmd.Flags().
+		StringVarP(&sessionConfigPath, "session-config", "c", "", "Path to the session config .json file")
+	sessionCmd.Flags().
+		StringVarP(&vocabListPath, "vocab-list", "l", "", "Path to the vocab list .txt file")
+	sessionCmd.Flags().
+		IntVarP(&numberOfQuestions, "number", "n", 0, "Number of questions for the session")
+	sessionCmd.Flags().
+		IntVarP(&serverPort, "server-port", "p", 5000, "Localhost port for the server (default is 5000)")
 
 	sessionCmd.MarkFlagRequired("session-config") //nolint:errcheck
 	sessionCmd.MarkFlagRequired("vocab-list")     //nolint:errcheck

--- a/src/client/internal/configtui/view.go
+++ b/src/client/internal/configtui/view.go
@@ -28,7 +28,13 @@ func (m Model) View() string {
 	b.WriteString(internal.LesserTitleStyle.Render(currentPage.Title) + "\n")
 	for i, setting := range currentPage.Settings {
 		settingSelected := i == m.selectedOption
-		b.WriteString(checkboxString(setting.DisplayName, setting.Checked, settingSelected) + "\n")
+		b.WriteString(
+			checkboxString(
+				setting.DisplayName,
+				setting.Checked,
+				settingSelected,
+			) + "\n",
+		)
 	}
 
 	b.WriteString(m.help.View(m.keys))

--- a/src/client/internal/sessiontui/init.go
+++ b/src/client/internal/sessiontui/init.go
@@ -43,98 +43,136 @@ func extractJSONObjects(jsonList []byte) ([][]byte, error) {
 }
 
 func (m Model) Init() (tea.Model, tea.Cmd) {
-	return m, tea.Batch(textinput.Blink, tea.SetWindowTitle("Vocab Tester Session"), func() tea.Msg {
-		vocabListData, err := os.ReadFile(m.vocabListPath)
-		if err != nil {
-			return errMsg{err}
-		}
-
-		sessionConfigPath := m.sessionConfigPath
-		sessionConfigData, err := os.ReadFile(sessionConfigPath)
-		if err != nil {
-			return errMsg{err}
-		}
-
-		var sessionConfig pkg.SessionConfig
-		err = json.Unmarshal(sessionConfigData, &sessionConfig)
-		if err != nil {
-			return errMsg{err}
-		}
-		sessionConfig.NumberOfQuestions = m.numberOfQuestions
-
-		sessionConfigData, err = json.Marshal(sessionConfig)
-		if err != nil {
-			return errMsg{err}
-		}
-
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-
-		client := &http.Client{}
-
-		vocabListURL := fmt.Sprintf("http://localhost:%d/%s", m.serverPort, vocabListPage)
-		vocabList := string(vocabListData)
-
-		req1, err := http.NewRequestWithContext(ctx, http.MethodPost, vocabListURL, bytes.NewBuffer([]byte(vocabList)))
-		if err != nil {
-			return errMsg{err}
-		}
-		req1.Header.Set("Content-Type", "text/plain")
-
-		resp1, err := client.Do(req1)
-		if err != nil {
-			return errMsg{err}
-		}
-		defer resp1.Body.Close()
-
-		if resp1.StatusCode != http.StatusOK {
-			return errMsg{fmt.Errorf("failed to post vocab list, status code: %d", resp1.StatusCode)}
-		}
-
-		sessionConfigURL := fmt.Sprintf("http://localhost:%d/%s", m.serverPort, sessionPage)
-		req2, err := http.NewRequestWithContext(ctx, http.MethodPost, sessionConfigURL, bytes.NewBuffer(sessionConfigData))
-		if err != nil {
-			return errMsg{err}
-		}
-		req2.Header.Set("Content-Type", "application/json")
-
-		resp2, err := client.Do(req2)
-		if err != nil {
-			return errMsg{err}
-		}
-		defer resp2.Body.Close()
-
-		if resp2.StatusCode != http.StatusOK {
-			return errMsg{fmt.Errorf("failed to post session config, status code: %d", resp2.StatusCode)}
-		}
-
-		body, err := io.ReadAll(resp2.Body)
-		if err != nil {
-			return errMsg{err}
-		}
-
-		objects, err := extractJSONObjects(body)
-		if err != nil {
-			return errMsg{err}
-		}
-
-		var response questions.Questions
-		for _, object := range objects {
-			part, err := unionjson.JSONUnmarshal[questions.Question](object)
+	return m, tea.Batch(
+		textinput.Blink,
+		tea.SetWindowTitle("Vocab Tester Session"),
+		func() tea.Msg {
+			vocabListData, err := os.ReadFile(m.vocabListPath)
 			if err != nil {
 				return errMsg{err}
 			}
-			response = append(response, part)
-		}
 
-		if len(response) != m.numberOfQuestions {
-			return errMsg{fmt.Errorf("expected %d questions, got %d", m.numberOfQuestions, len(response))}
-		}
+			sessionConfigPath := m.sessionConfigPath
+			sessionConfigData, err := os.ReadFile(sessionConfigPath)
+			if err != nil {
+				return errMsg{err}
+			}
 
-		return initOkMsg{
-			vocabList:     vocabList,
-			sessionConfig: sessionConfig,
-			questions:     response,
-		}
-	})
+			var sessionConfig pkg.SessionConfig
+			err = json.Unmarshal(sessionConfigData, &sessionConfig)
+			if err != nil {
+				return errMsg{err}
+			}
+			sessionConfig.NumberOfQuestions = m.numberOfQuestions
+
+			sessionConfigData, err = json.Marshal(sessionConfig)
+			if err != nil {
+				return errMsg{err}
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			client := &http.Client{}
+
+			vocabListURL := fmt.Sprintf(
+				"http://localhost:%d/%s",
+				m.serverPort,
+				vocabListPage,
+			)
+			vocabList := string(vocabListData)
+
+			req1, err := http.NewRequestWithContext(
+				ctx,
+				http.MethodPost,
+				vocabListURL,
+				bytes.NewBuffer([]byte(vocabList)),
+			)
+			if err != nil {
+				return errMsg{err}
+			}
+			req1.Header.Set("Content-Type", "text/plain")
+
+			resp1, err := client.Do(req1)
+			if err != nil {
+				return errMsg{err}
+			}
+			defer resp1.Body.Close()
+
+			if resp1.StatusCode != http.StatusOK {
+				return errMsg{
+					fmt.Errorf(
+						"failed to post vocab list, status code: %d",
+						resp1.StatusCode,
+					),
+				}
+			}
+
+			sessionConfigURL := fmt.Sprintf(
+				"http://localhost:%d/%s",
+				m.serverPort,
+				sessionPage,
+			)
+			req2, err := http.NewRequestWithContext(
+				ctx,
+				http.MethodPost,
+				sessionConfigURL,
+				bytes.NewBuffer(sessionConfigData),
+			)
+			if err != nil {
+				return errMsg{err}
+			}
+			req2.Header.Set("Content-Type", "application/json")
+
+			resp2, err := client.Do(req2)
+			if err != nil {
+				return errMsg{err}
+			}
+			defer resp2.Body.Close()
+
+			if resp2.StatusCode != http.StatusOK {
+				return errMsg{
+					fmt.Errorf(
+						"failed to post session config, status code: %d",
+						resp2.StatusCode,
+					),
+				}
+			}
+
+			body, err := io.ReadAll(resp2.Body)
+			if err != nil {
+				return errMsg{err}
+			}
+
+			objects, err := extractJSONObjects(body)
+			if err != nil {
+				return errMsg{err}
+			}
+
+			var response questions.Questions
+			for _, object := range objects {
+				part, err := unionjson.JSONUnmarshal[questions.Question](object)
+				if err != nil {
+					return errMsg{err}
+				}
+				response = append(response, part)
+			}
+
+			if len(response) != m.numberOfQuestions {
+				return errMsg{
+					fmt.Errorf(
+						"expected %d questions, got %d",
+						m.numberOfQuestions,
+						len(response),
+					),
+				}
+			}
+
+			return initOkMsg{
+				vocabList:     vocabList,
+				sessionConfig: sessionConfig,
+				questions:     response,
+			}
+		},
+	)
 }

--- a/src/client/internal/sessiontui/update.go
+++ b/src/client/internal/sessiontui/update.go
@@ -75,7 +75,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	var requiredPPTextinputs int
 	if m.questionMode == enums.PrincipalParts {
-		requiredPPTextinputs = len(currentQuestionStruct.(*questions.PrincipalPartsQuestion).PrincipalParts)
+		requiredPPTextinputs = len(
+			currentQuestionStruct.(*questions.PrincipalPartsQuestion).PrincipalParts,
+		)
 	}
 
 	switch msg := msg.(type) {

--- a/src/client/internal/sessiontui/view.go
+++ b/src/client/internal/sessiontui/view.go
@@ -27,7 +27,10 @@ func questionStringRegular(q questions.Question) string {
 }
 
 func questionStringPrincipalParts(q questions.Question) string {
-	return fmt.Sprintf("Principal parts of %s", internal.ItalicStyle.Render(q.(*questions.PrincipalPartsQuestion).Prompt))
+	return fmt.Sprintf(
+		"Principal parts of %s",
+		internal.ItalicStyle.Render(q.(*questions.PrincipalPartsQuestion).Prompt),
+	)
 }
 
 func questionStringMultipleChoice(q questions.Question) string {
@@ -80,12 +83,19 @@ func (m Model) View() string {
 			b.WriteString(lipgloss.JoinHorizontal(
 				lipgloss.Top,
 				m.textinput.View(),
-				internal.IncorrectStyle.Render(fmt.Sprintf(" ✕ %s", questions.GetMainAnswer(currentQuestionStruct).(string))),
+				internal.IncorrectStyle.Render(
+					fmt.Sprintf(
+						" ✕ %s",
+						questions.GetMainAnswer(currentQuestionStruct).(string),
+					),
+				),
 			))
 		}
 
 	case enums.PrincipalParts:
-		requiredPPTextinputs := len(currentQuestionStruct.(*questions.PrincipalPartsQuestion).PrincipalParts)
+		requiredPPTextinputs := len(
+			currentQuestionStruct.(*questions.PrincipalPartsQuestion).PrincipalParts,
+		)
 
 		m.textinput.SetWidth(m.width)
 
@@ -120,7 +130,9 @@ func (m Model) View() string {
 					b.WriteString(lipgloss.JoinHorizontal(
 						lipgloss.Top,
 						m.principalPartsTextinputs[i].View(),
-						internal.IncorrectStyle.Render(fmt.Sprintf(" ✕ %s", x)),
+						internal.IncorrectStyle.Render(
+							fmt.Sprintf(" ✕ %s", x),
+						),
 					))
 				} else {
 					b.WriteString(m.principalPartsTextinputs[i].View())
@@ -164,10 +176,24 @@ func (m Model) View() string {
 		}
 	case enums.Correct:
 		b.WriteString("Answer is correct!\n\n")
-		b.WriteString(fmt.Sprintf("Score: %d/%d (%.0f%%)\n", m.score, m.currentQuestion, 100*float64(m.score)/float64(m.currentQuestion)))
+		b.WriteString(
+			fmt.Sprintf(
+				"Score: %d/%d (%.0f%%)\n",
+				m.score,
+				m.currentQuestion,
+				100*float64(m.score)/float64(m.currentQuestion),
+			),
+		)
 	case enums.Incorrect:
 		b.WriteString("Answer is incorrect!\n\n")
-		b.WriteString(fmt.Sprintf("Score: %d/%d (%.0f%%)\n", m.score, m.currentQuestion, 100*float64(m.score)/float64(m.currentQuestion)))
+		b.WriteString(
+			fmt.Sprintf(
+				"Score: %d/%d (%.0f%%)\n",
+				m.score,
+				m.currentQuestion,
+				100*float64(m.score)/float64(m.currentQuestion),
+			),
+		)
 	}
 
 	b.WriteString(m.help.View(m.keys))


### PR DESCRIPTION
Using golines to enforce line length. Running `go tool golines -w --max-len=100 --tab-len=8 --ignored-dirs=_vendor .` and then removing changes to tests and other unneeded edits.