### PR TITLE
🐛 fix: fixing fifth declension detection

### DIFF
--- a/src/core/accido/_class_noun.py
+++ b/src/core/accido/_class_noun.py
@@ -192,7 +192,7 @@ class Noun(_Word):
         # The ordering of this is strange because
         # e.g. ending -ei ends in 'i' as well as 'ei'
         # so 5th declension check must come before 2nd declension check, etc.
-        if self.genitive.endswith("ei"):
+        if self.genitive.endswith("ei") and self.nominative.endswith("es"):
             self.declension = 5
             self._stem = self.genitive[:-2]  # diei > di-
         elif self.genitive.endswith("ae"):

--- a/tests/accido_test/noun_test.py
+++ b/tests/accido_test/noun_test.py
@@ -18,8 +18,8 @@ class TestNounErrors:
 
     def test_errors_fifth_declension_neuter(self):
         with pytest.raises(InvalidInputError) as error:
-            Noun("puer", "puerei", gender=Gender.NEUTER, meaning="boy")
-        assert str(error.value) == "Fifth declension nouns cannot be neuter. (noun 'puer' given)"
+            Noun("pueres", "puerei", gender=Gender.NEUTER, meaning="boy")  # doesn't really exist
+        assert str(error.value) == "Fifth declension nouns cannot be neuter. (noun 'pueres' given)"
 
 
 class TestNounDunder:


### PR DESCRIPTION
Avoids issues with words such as `deus, dei` which are second declension but have a genitive ending in 'ei'.
This might not be foolproof – further testing is needed.