### PR TITLE
🤖 ci: updating ubuntu version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04-arm, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, macos-13, macos-14]
         python:
           - 3.13.1
       fail-fast: false


### PR DESCRIPTION
The Ubuntu 20.04 image was removed from Github Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the build process to use Ubuntu 22.04 instead of Ubuntu 20.04 in the automated workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->