### PR TITLE
🐛 fix: fix interrogate workflow

### DIFF
--- a/.github/workflows/interrogate.yml
+++ b/.github/workflows/interrogate.yml
@@ -25,11 +25,11 @@ jobs:
         with:
           python-version-file: ".python-version"
 
+      - name: Install interrogate
+        run: pipx install interrogate
+
       - name: Run interrogate
-        uses: rduo1009/python-interrogate-check@main
-        with:
-          path: "src"
-          badge-location: "docs/assets/interrogate_badge.svg"
+        run: interrogate --fail-under 80 --generate-badge docs/assets/interrogate_badge.svg src -c setup.cfg
 
       - name: Prepare artifact
         run: |
@@ -38,7 +38,9 @@ jobs:
             echo "Error: Badge file '$badge_path' not found. Interrogate might have failed to generate it."
             exit 1
           fi
+          # Ensure _artifact directory exists
           mkdir -p _artifact
+          # Copy the badge to the artifact directory
           cp "$badge_path" _artifact/interrogate_badge.svg
           echo "Badge prepared for upload."
 

--- a/docs/assets/interrogate_badge.svg
+++ b/docs/assets/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 94.3%</title>
+    <title>interrogate: 91.0%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">94.3%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">94.3%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">91.0%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">91.0%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">


### PR DESCRIPTION
Removes the rduo1009/python-interrogate-check dependency and instead installs interrogate using pipx directly.

The interrogate command is run with the specified options: `--fail-under 80 --generate-badge docs/assets/interrogate_badge.svg src -c setup.cfg`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the workflow to install and run the documentation coverage tool directly, improving reliability and reducing external dependencies.
	- Enhanced workflow robustness by ensuring proper preparation and copying of the coverage badge for artifact upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->